### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/Arm7Bot/keywords.txt
+++ b/Arm7Bot/keywords.txt
@@ -5,12 +5,12 @@
 #######################################
 # Class (KEYWORD1)
 #######################################
-Arm7Bot	KEYWORD1	Arm7Bot
-ForceFilter	KEYWORD1	ForceFilter
-MedianFilter	KEYWORD1	MedianFilter
-PressFilter	KEYWORD1	PressFilter
-PVector	KEYWORD1	PVector
-ARMPORT	KEYWORD1    Arm
+Arm7Bot	KEYWORD1
+ForceFilter	KEYWORD1
+MedianFilter	KEYWORD1
+PressFilter	KEYWORD1
+PVector	KEYWORD1
+ARMPORT	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format